### PR TITLE
要素間の間隔を広げる

### DIFF
--- a/src/components/File.scss
+++ b/src/components/File.scss
@@ -1,6 +1,6 @@
 .file {
   max-width: 480px;
-  margin: 1rem 0;
+  margin: 0.5rem 0;
 }
 
 figure.file {

--- a/src/components/File.scss
+++ b/src/components/File.scss
@@ -1,5 +1,6 @@
 .file {
   max-width: 480px;
+  margin: 1rem 0;
 }
 
 figure.file {

--- a/src/components/MessageWidget.scss
+++ b/src/components/MessageWidget.scss
@@ -8,12 +8,12 @@
 .message {
   >* {
     margin: 0.5rem 0;
-  }
-  >*:first-child {
-    margin-top: 0;
-  }
-  >*:last-child {
-    margin-bottom: 0;
+    &:first-child {
+      margin-top: 0;
+    }
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   header {

--- a/src/components/MessageWidget.scss
+++ b/src/components/MessageWidget.scss
@@ -6,8 +6,6 @@
 }
 
 .message {
-  >* {
-    margin: 0.5rem 0;
   > * {
     margin: 1rem 0;
     &:first-child {

--- a/src/components/MessageWidget.scss
+++ b/src/components/MessageWidget.scss
@@ -6,6 +6,16 @@
 }
 
 .message {
+  >* {
+    margin: 0.5rem 0;
+  }
+  >*:first-child {
+    margin-top: 0;
+  }
+  >*:last-child {
+    margin-bottom: 0;
+  }
+
   header {
     display: flex;
     align-items: baseline;

--- a/src/components/MessageWidget.scss
+++ b/src/components/MessageWidget.scss
@@ -8,6 +8,7 @@
 .message {
   >* {
     margin: 0.5rem 0;
+    margin: 1rem 0;
     &:first-child {
       margin-top: 0;
     }

--- a/src/components/MessageWidget.scss
+++ b/src/components/MessageWidget.scss
@@ -8,6 +8,7 @@
 .message {
   >* {
     margin: 0.5rem 0;
+  > * {
     margin: 1rem 0;
     &:first-child {
       margin-top: 0;


### PR DESCRIPTION
- アイコン・名前、本文、"traQで開く"間の間隔を調整
- 複数画像が添付されていた時、画像間に間隔が無かったのを修正

![image](https://user-images.githubusercontent.com/59188998/118374080-2f4b2180-b5f5-11eb-904f-db172061a1fc.png)
